### PR TITLE
Pass disc reference to flusher().

### DIFF
--- a/fdc.js
+++ b/fdc.js
@@ -44,10 +44,10 @@ export function discFor(fdc, name, stringData, onChange) {
         return res;
     }
 
-    return new BaseDisc(fdc, name, data, () => {
+    return new BaseDisc(fdc, name, data, (disc) => {
         if (!changed()) return;
         if (onChange) {
-            onChange(this.data);
+            onChange(disc.data);
         }
     });
 }
@@ -64,10 +64,10 @@ export function localDisc(fdc, name) {
         console.log("Loading browser-local disc " + name);
         data = utils.stringToUint8Array(dataString);
     }
-    return new BaseDisc(fdc, discName, data, () => {
-        const str = utils.uint8ArrayToString(this.data);
+    return new BaseDisc(fdc, discName, data, (disc) => {
         try {
-            window.localStorage.setItem(this.name, str);
+            const str = utils.uint8ArrayToString(disc.data);
+            window.localStorage.setItem(disc.name, str);
         } catch (e) {
             window.alert("Writing to localStorage failed: " + e);
         }
@@ -173,7 +173,7 @@ export function BaseDisc(fdc, name, data, flusher) {
     });
 
     BaseDisc.prototype.flush = () => {
-        if (this.flusher) this.flusher();
+        if (this.flusher) this.flusher(this);
     };
     BaseDisc.prototype.seek = (track) => {
         this.seekOffset = track * this.sectorsPerTrack * 256;

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                   <a href="#google-drive" class="dropdown-item" id="open-drive-link">From Google Drive</a>
                 </li>
                 <hr />
-                <li class="if-drive-available">
+                <li>
                   <a href="#download-drive" class="dropdown-item" id="download-drive-link">Download drive 0 image</a>
                 </li>
               </ul>


### PR DESCRIPTION
Fixes use of browser local storage for discs in Firefox 102.0.  Writing to disc failed because `this` was undefined in the function referenced by `BaseDisc.flusher()`, and the `BaseDisc.data` member could not be retrieved.

Examples of failing URLs:
[*FORM 80 0](https://bbc.godbolt.org/?model=Master&disc1=local:foo&autotype=%2AFORM%2080%200%0AYYY)
[SAVE "BAR"](https://bbc.godbolt.org/?model=Master&disc1=local:bar&autotype=SAVE%22BAR%22%0A)

The menu option to download the disc image is enabled in all cases, to mitigate possible dataloss if local storage is cleared unexpectedly (in my configuration it is happening on browser close, for localhost only.)