### PR TITLE
Set 3:1 Teletext flash ratio.

### DIFF
--- a/teletext.js
+++ b/teletext.js
@@ -240,8 +240,10 @@ Teletext.prototype.setDEW = function (level) {
     this.scanlineCounter = 0;
     this.secondHalfOfDouble = false;
 
-    if (++this.flashTime === 48) this.flashTime = 0;
-    this.flashOn = this.flashTime < 16;
+    // 3:1 flash ratio.
+    if (++this.flashTime === 64) this.flashTime = 0;
+    // Flashing text and the cursor should go out at the same time.
+    this.flashOn = this.flashTime > 48;
 };
 
 Teletext.prototype.setDISPTMG = function (level) {


### PR DESCRIPTION
Adjusts the flash periods of flashing text and graphics in `MODE 7` to 48 fields on, 16 fields off, and has them extinguished at the same time as a slow-flashing cursor.  Matching the behaviour of the SAA 5050 and MC6845.

Synchrony is not critical: as the two chips count fields independently and in lockstep, a `MODE` change typically preserves their respective counts but may occasionally desynchronise them by one field.